### PR TITLE
Fix start end link column type

### DIFF
--- a/src/main/java/com/arup/cml/abm/kpi/tablesaw/TablesawKpiCalculator.java
+++ b/src/main/java/com/arup/cml/abm/kpi/tablesaw/TablesawKpiCalculator.java
@@ -34,6 +34,10 @@ import java.time.Instant;
 import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
 import java.util.*;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
 import java.util.function.Consumer;
 
 import static tech.tablesaw.aggregate.AggregateFunctions.*;

--- a/src/main/java/com/arup/cml/abm/kpi/tablesaw/TablesawKpiCalculator.java
+++ b/src/main/java/com/arup/cml/abm/kpi/tablesaw/TablesawKpiCalculator.java
@@ -34,10 +34,6 @@ import java.time.Instant;
 import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
 import java.util.*;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.Map;
-import java.util.Optional;
 import java.util.function.Consumer;
 
 import static tech.tablesaw.aggregate.AggregateFunctions.*;
@@ -110,6 +106,8 @@ public class TablesawKpiCalculator implements KpiCalculator {
         columnMapping.put("start_y", ColumnType.DOUBLE);
         columnMapping.put("end_x", ColumnType.DOUBLE);
         columnMapping.put("end_y", ColumnType.DOUBLE);
+        columnMapping.put("start_link", ColumnType.STRING);
+        columnMapping.put("end_link", ColumnType.STRING);
         columnMapping.put("start_activity_type", ColumnType.STRING);
         columnMapping.put("start_facility_id", ColumnType.STRING);
         columnMapping.put("end_activity_type", ColumnType.STRING);


### PR DESCRIPTION
This PR is meant to address the error of start_link and end_link being read as integers (reported in #95). 

If this fix is correct, does it need to be made [here](https://github.com/arup-group/gelato/blob/main/src/test/java/com/arup/cml/abm/kpi/tablesaw/PerformanceDebugMatsimAccessToMobility.java#L111) as well?